### PR TITLE
feat: GH-492 update function host.get to normalise data

### DIFF
--- a/lib/zabbixapi/classes/hosts.rb
+++ b/lib/zabbixapi/classes/hosts.rb
@@ -75,5 +75,50 @@ class ZabbixApi
       hostid = get_id(host: data[:host])
       hostid ? update(data.merge(hostid: hostid)) : create(data)
     end
+
+    # Update Zabbix object using API
+    #
+    # @param data [Hash] Should include object's id field name (identify) and id value
+    # @param force [Boolean] Whether to force an object update even if provided data matches Zabbix
+    # @raise [ApiError] Error returned when there is a problem with the Zabbix API call.
+    # @raise [HttpError] Error raised when HTTP status from Zabbix Server response is not a 200 OK.
+    # @return [Integer] The object id if a single object is created
+    # @return [Boolean] True/False if multiple objects are created
+    def update(data, force = false)
+      log "[DEBUG] Call update with parameters: #{data.inspect}"
+
+      dump = {}
+      dump_by_id(key.to_sym => data[key.to_sym]).each do |item|
+        dump = symbolize_keys(item) if item[key].to_i == data[key.to_sym].to_i
+      end
+       # Convert 'hostgroups' to 'groups' if 'hostgroups' is present in dump
+      # This is due to host.get returning existing data as the hostgroups key
+      # but we have to update as the groups key
+      if dump[:hostgroups]
+        dump[:groups] = dump.delete(:hostgroups).map { |g| { groupid: g[:groupid].to_i } }
+      end
+      # Normalsation setps
+      # 1. Only compare the fields in `data`, since we only care if *those* differ
+      dump = dump.select { |k, _| data.key?(k) }
+      # 2. Ensure groups are ordered correctly
+      if dump[:groups]
+        dump[:groups] = dump[:groups].map { |g| { groupid: g[:groupid].to_i } }.sort_by { |g| g[:groupid] }
+      end
+      log "[DEBUG] dump is: #{dump}"
+
+      if data[:groups]
+        data[:groups] = data[:groups].map { |g| { groupid: g["groupid"].to_i } }.sort_by { |g| g[:groupid] }
+      end
+      log "[DEBUG] data is: #{data}"
+
+      if hash_equals?(dump, data) && !force
+        log "[DEBUG] Equal keys #{dump} and #{data}, skip update"
+        data[key.to_sym].to_i
+      else
+        data_update = [data]
+        result = @client.api_request(method: "#{method_name}.update", params: data_update)
+        parse_keys result
+      end
+    end
   end
 end

--- a/lib/zabbixapi/version.rb
+++ b/lib/zabbixapi/version.rb
@@ -1,3 +1,3 @@
 class ZabbixApi
-  VERSION = '6.0.0-alpha4'.freeze
+  VERSION = '6.0.0-alpha13'.freeze
 end


### PR DESCRIPTION
- only compare fields that we are passing in.
- host.get returns value as `hostgroups` and the update parameter accepts groups, meaning that we need to rename `hostgroups` to `groups` when `hash_equals?` gets called